### PR TITLE
fix: 🐛 vercel build error due to lightweightchart type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "src",
-  "version": "0.8.0+54.1",
+  "version": "0.8.0+54.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "src",
-  "version": "0.8.0+53.2",
+  "version": "0.8.0+54.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/candlestick_chart/candlestick_chart.tsx
+++ b/src/components/candlestick_chart/candlestick_chart.tsx
@@ -110,7 +110,7 @@ interface IChartSpecProps {
 
 // ToDo: 從 props 拿資料；圖表樣式、長寬、時間區間、資料數量
 const createSpec = ({timespan, dataSize, chartHeight, chartWidth}: IChartSpecProps) => {
-  const locale: LocalizationOptions = {
+  const locale = {
     locale: 'zh-TW',
     dateFormat: 'yyyy-MM-dd',
   };

--- a/src/components/candlestick_chart/candlestick_chart.tsx
+++ b/src/components/candlestick_chart/candlestick_chart.tsx
@@ -108,9 +108,14 @@ interface IChartSpecProps {
   chartWidth: number;
 }
 
+interface ICustomizedLocalizationOptions {
+  locale: string;
+  dateFormat: string;
+}
+
 // ToDo: 從 props 拿資料；圖表樣式、長寬、時間區間、資料數量
 const createSpec = ({timespan, dataSize, chartHeight, chartWidth}: IChartSpecProps) => {
-  const locale = {
+  const locale: ICustomizedLocalizationOptions = {
     locale: 'zh-TW',
     dateFormat: 'yyyy-MM-dd',
   };


### PR DESCRIPTION
### DEVELOP

- CandlestickChart

### CHECK LIST

- [Naming convention](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md) verification: checked
- Coding style verification: checked
- new Library: 0
- new Class / Component: 0
- new loop: 0
- new recursive: 0
- high risk: 0
- new sql: 0

### UML

- [Sequence Diagram 001 (interaction between user, frontend and backend)](https://github.com/CAFECA-IO/Documents/blob/main/TBD/TBDSD00001.md)
- [Sequence Diagram 002 (background mechanism)](https://github.com/CAFECA-IO/Documents/blob/main/TBD/TBDSD00002.md)
- [Component Diagram](https://github.com/CAFECA-IO/Documents/blob/main/TBD/TBDCP00001.md)
- [Class Diagram](https://github.com/CAFECA-IO/Documents/blob/main/TBD/TBDCD00001.md)
- [Global context document](https://www.notion.so/d93ac7c941c94fb6b173d34a7bc4e959?pvs=21)
- [Table of interface](https://github.com/CAFECA-IO/EventReport/blob/main/meeting/20230106_tbd_mvp.md)