### PR TITLE
fix: 🐛 pop up critical announcement whether the user read

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "src",
-  "version": "0.8.0+74.4",
+  "version": "0.8.0+75.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "src",
-  "version": "0.8.0+75.0",
+  "version": "0.8.0+75.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "src",
-  "version": "0.8.0+75.1.1",
+  "version": "0.8.0+75.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/notification/notification.tsx
+++ b/src/components/notification/notification.tsx
@@ -25,22 +25,22 @@ export default function Notification({
 
   /* Info: (20230522 - Julian) 初始化完成就去抓 notificationCtx ，檢查有沒有重要通知 */
   useEffect(() => {
-    notificationCtx.init();
-
-    notificationCtx.unreadNotifications.map(v => {
-      if (v.notificationLevel === NotificationLevel.CRITICAL) {
-        globalCtx.dataAnnouncementModalHandler({
-          id: v.id,
-          title: v.title,
-          content: v.content,
-          numberOfButton: 1,
-          reactionOfButton: '',
-          messageType: MessageType.ANNOUNCEMENT,
-        });
-        globalCtx.visibleAnnouncementModalHandler();
-      }
-    });
-  }, []);
+    if (notificationCtx.isInit) {
+      notificationCtx.unreadNotifications.map(v => {
+        if (v.notificationLevel === NotificationLevel.CRITICAL) {
+          globalCtx.dataAnnouncementModalHandler({
+            id: v.id,
+            title: v.title,
+            content: v.content,
+            numberOfButton: 1,
+            reactionOfButton: '',
+            messageType: MessageType.ANNOUNCEMENT,
+          });
+          globalCtx.visibleAnnouncementModalHandler();
+        }
+      });
+    }
+  }, [notificationCtx.isInit]);
 
   let timer: NodeJS.Timeout;
 

--- a/src/components/notification/notification.tsx
+++ b/src/components/notification/notification.tsx
@@ -25,6 +25,8 @@ export default function Notification({
 
   /* Info: (20230522 - Julian) 初始化完成就去抓 notificationCtx ，檢查有沒有重要通知 */
   useEffect(() => {
+    notificationCtx.init();
+
     notificationCtx.unreadNotifications.map(v => {
       if (v.notificationLevel === NotificationLevel.CRITICAL) {
         globalCtx.dataAnnouncementModalHandler({

--- a/src/components/notification_item/notification_item.tsx
+++ b/src/components/notification_item/notification_item.tsx
@@ -34,8 +34,6 @@ export default function NotificationItem(notificationItem: INotificationItem) {
       ? MessageType.ANNOUNCEMENT
       : MessageType.NOTIFICATION;
 
-  const displayTime = timestampToString(timestamp);
-
   const itemClickHandler = () => {
     globalCtx.dataAnnouncementModalHandler({
       id: id,

--- a/src/contexts/notification_context.tsx
+++ b/src/contexts/notification_context.tsx
@@ -142,6 +142,8 @@ export const NotificationProvider = ({children}: INotificationProvider) => {
 
     updatedNotifications.forEach(notification => {
       const cookieValue = getCookieByName(`notificationRead_${notification.id}`);
+      // eslint-disable-next-line no-console
+      console.log('cookieValue', cookieValue);
       if (cookieValue) {
         if (!isCookieExpired(cookieValue)) {
           notification.isRead = true;

--- a/src/contexts/notification_context.tsx
+++ b/src/contexts/notification_context.tsx
@@ -146,8 +146,7 @@ export const NotificationProvider = ({children}: INotificationProvider) => {
 
     updatedNotifications.forEach(notification => {
       const cookieValue = getCookieByName(`notificationRead_${notification.id}`);
-      // eslint-disable-next-line no-console
-      console.log('cookieValue', cookieValue);
+
       if (cookieValue) {
         if (!isCookieExpired(cookieValue)) {
           notification.isRead = true;

--- a/src/contexts/notification_context.tsx
+++ b/src/contexts/notification_context.tsx
@@ -36,6 +36,7 @@ export interface INotificationContext {
   clearException: () => void;
   removeException: (props: IErrorSearchProps, searchBy: string) => void;
   getSeverestException: () => IException[];
+  isInit: boolean;
 }
 
 export const NotificationContext = createContext<INotificationContext>({
@@ -50,6 +51,7 @@ export const NotificationContext = createContext<INotificationContext>({
   clearException: () => null,
   removeException: () => null,
   getSeverestException: () => [],
+  isInit: false,
 });
 
 export const NotificationProvider = ({children}: INotificationProvider) => {
@@ -63,6 +65,8 @@ export const NotificationProvider = ({children}: INotificationProvider) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [unreadNotifications, setUnreadNotifications, unreadNotificationsRef] =
     useState<INotificationItem[]>(dummyUnReadNotifications);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [isInit, setIsInit, isInitRef] = useState<boolean>(false);
 
   const getSeverestException = (): IException[] => {
     return exceptionCollector.getSeverest();
@@ -179,6 +183,7 @@ export const NotificationProvider = ({children}: INotificationProvider) => {
 
   const init = async () => {
     checkAndResetNotifications();
+    setIsInit(true);
     return await Promise.resolve();
   };
 
@@ -219,6 +224,7 @@ export const NotificationProvider = ({children}: INotificationProvider) => {
     clearException,
     removeException,
     getSeverestException,
+    isInit: isInitRef.current,
   };
 
   return (


### PR DESCRIPTION
### DEVELOP

- Notification
- notificationContext

### CHECK LIST

- [Naming convention](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md) verification: checked
- Coding style verification: checked
- new Library: 0
- new Class / Component: 0
- new loop: 0
- new recursive: 0
- high risk: 0
- new sql: 0

### UML

- [Sequence Diagram 001 (interaction between user, frontend and backend)](https://github.com/CAFECA-IO/Documents/blob/main/TBD/TBDSD00001.md)
- [Sequence Diagram 002 (background mechanism)](https://github.com/CAFECA-IO/Documents/blob/main/TBD/TBDSD00002.md)
- [Component Diagram](https://github.com/CAFECA-IO/Documents/blob/main/TBD/TBDCP00001.md)
- [Class Diagram](https://github.com/CAFECA-IO/Documents/blob/main/TBD/TBDCD00001.md)
- [Global context document](https://www.notion.so/d93ac7c941c94fb6b173d34a7bc4e959?pvs=21)
- [Table of interface](https://github.com/CAFECA-IO/EventReport/blob/main/meeting/20230106_tbd_mvp.md)